### PR TITLE
updated link checker to accept server response 418

### DIFF
--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -25,7 +25,7 @@ jobs:
           pip3 install requests
       - name: amend linkcheckerrc to ignore 403 errors
         run: |
-            sed -i '/#ignoreerrors=/a ignoreerrors=^http* ^403 Forbidden' /home/runner/.local/lib/python3.10/site-packages/linkcheck/data/linkcheckerrc
+            sed -i '/#ignoreerrors=/a ignoreerrors=\n ^http* ^403 Forbidden\n ^http* ^418 Unknown Code' /home/runner/.local/lib/python3.10/site-packages/linkcheck/data/linkcheckerrc
       - name: run linkchecker
         run: |
           cd $GITHUB_WORKSPACE/


### PR DESCRIPTION
Updates link checker to accept server status code 418 as valid, which is currently returned by the link: http://ieeexplore.ieee.org/document/7336443/

