### PR TITLE
Find linkcheckerrc

### DIFF
--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -23,9 +23,15 @@ jobs:
           pip3 install --upgrade pip
           pip3 install linkchecker==10.2.1
           pip3 install requests
+      - name: search for linkcheckerrc file
+        id: find-file
+        run: |
+          file_path=$(find /home/runner/.local/lib/python3.* -name linkcheckerrc)
+          echo "linkcheckerrc located here: $file_path"
+          echo "::set-output name=file_path::$file_path"
       - name: amend linkcheckerrc to ignore 403 errors
         run: |
-            sed -i '/#ignoreerrors=/a ignoreerrors=\n ^http* ^403 Forbidden\n ^http* ^418 Unknown Code' /home/runner/.local/lib/python3.10/site-packages/linkcheck/data/linkcheckerrc
+          sed -i '/#ignoreerrors=/a ignoreerrors=\n ^http* ^403 Forbidden\n ^http* ^418 Unknown Code' ${{ steps.find-file.outputs.file_path }}
       - name: run linkchecker
         run: |
           cd $GITHUB_WORKSPACE/

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -28,10 +28,10 @@ jobs:
         run: |
           file_path=$(find /home/runner/.local/lib/python3.* -name linkcheckerrc)
           echo "linkcheckerrc located here: $file_path"
-          echo "::set-output name=file_path::$file_path"
+          echo "file_path=$file_path" >> $GITHUB_STATE
       - name: amend linkcheckerrc to ignore 403 errors
         run: |
-          sed -i '/#ignoreerrors=/a ignoreerrors=\n ^http* ^403 Forbidden\n ^http* ^418 Unknown Code' ${{ steps.find-file.outputs.file_path }}
+          sed -i '/#ignoreerrors=/a ignoreerrors=\n ^http* ^403 Forbidden\n ^http* ^418 Unknown Code' $(echo ${{ state.file_path }})
       - name: run linkchecker
         run: |
           cd $GITHUB_WORKSPACE/

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -28,10 +28,10 @@ jobs:
         run: |
           file_path=$(find /home/runner/.local/lib/python3.* -name linkcheckerrc)
           echo "linkcheckerrc located here: $file_path"
-          echo "file_path=$file_path" >> $GITHUB_STATE
+          echo "file_path=$file_path" >> $GITHUB_OUTPUT
       - name: amend linkcheckerrc to ignore 403 errors
         run: |
-          sed -i '/#ignoreerrors=/a ignoreerrors=\n ^http* ^403 Forbidden\n ^http* ^418 Unknown Code' $(echo ${{ state.file_path }})
+          sed -i '/#ignoreerrors=/a ignoreerrors=\n ^http* ^403 Forbidden\n ^http* ^418 Unknown Code' $(echo ${{ steps.find-file.outputs.file_path }})
       - name: run linkchecker
         run: |
           cd $GITHUB_WORKSPACE/

--- a/.github/workflows/linkchecker.yaml
+++ b/.github/workflows/linkchecker.yaml
@@ -3,11 +3,11 @@ on:
   pull_request:
     branches:
       - main
-      - LinkChecker
+      - find_linkcheckerrc
   push:
     branches:
       - main
-      - LinkChecker
+      - find_linkcheckerrc
   schedule:
     # run every Sunday at 00:00 UTC
     - cron: '0 0 * * 0'


### PR DESCRIPTION
@LSchwiebert - It looks like you're right and ubuntu-latest now uses 24.04, which includes a newer version of Python.  This PR updates the Link Checker workflow script to search for the needed linkcheckerrc file instead of using a hard-coded path that specifies Python 3.10.

I'll also apply this update to the JETSCAPE site.